### PR TITLE
Add sha256 field to AndroidAppDeliveryData proto

### DIFF
--- a/src/main/proto/GooglePlay.proto
+++ b/src/main/proto/GooglePlay.proto
@@ -15,6 +15,7 @@ message AndroidAppDeliveryData {
   optional bool immediateStartNeeded = 10;
   optional AndroidAppPatchData patchData = 11;
   optional EncryptionParams encryptionParams = 12;
+  optional string sha256 = 19;
 }
 message AndroidAppPatchData {
   optional int32 baseVersionCode = 1;


### PR DESCRIPTION
Added field to app delivery data that contains the APK File's sha256. 

Please release 0.45 after merging, so I don't have to maintain my own fork for this change :)