### PR TITLE
Force Travis to use Trusty instead of Xenial for its builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 jdk:
   - oraclejdk8


### PR DESCRIPTION
openjdk8 is not supported on Xenial on Travis, and builds fail
during setup without this explicit distribution requirement.